### PR TITLE
Bugfix/set timeline markers on unintilized mls

### DIFF
--- a/mls/src/main/java/tv/mycujoo/mcls/api/MLS.kt
+++ b/mls/src/main/java/tv/mycujoo/mcls/api/MLS.kt
@@ -21,6 +21,7 @@ import tv.mycujoo.mcls.player.IPlayer
 import tv.mycujoo.mcls.utils.UserPreferencesUtils
 import tv.mycujoo.mcls.widgets.MLSPlayerView
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * main component of MLS(MCLS) SDK.
@@ -28,6 +29,7 @@ import javax.inject.Inject
  * @constructor takes MLSBuilder and returns implementation of MLSAbstract
  * @see MLSAbstract
  */
+@Singleton
 class MLS @Inject constructor(
     @ApplicationContext private val context: Context,
     private val videoPlayerMediator: VideoPlayerMediator,

--- a/mls/src/main/java/tv/mycujoo/mcls/core/AnnotationFactory.kt
+++ b/mls/src/main/java/tv/mycujoo/mcls/core/AnnotationFactory.kt
@@ -397,6 +397,7 @@ class AnnotationFactory @Inject constructor(
     /**endregion */
 
     override fun clearOverlays() {
+        localActions.clear()
         annotationListener.clearScreen()
     }
 }

--- a/mls/src/main/java/tv/mycujoo/mcls/core/VideoPlayerMediator.kt
+++ b/mls/src/main/java/tv/mycujoo/mcls/core/VideoPlayerMediator.kt
@@ -48,6 +48,7 @@ import tv.mycujoo.mcls.widgets.PlayerControllerMode
 import tv.mycujoo.mcls.widgets.RemotePlayerControllerListener
 import java.lang.RuntimeException
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * Manages video-player related components.
@@ -56,6 +57,7 @@ import javax.inject.Inject
  * @param dispatcher coroutine scope context used in I/O bound calls
  * @param dataManager data manager which holds current data(event) loaded
  */
+@Singleton
 class VideoPlayerMediator @Inject constructor(
     private val viewHandler: IViewHandler,
     private val reactorSocket: IReactorSocket,

--- a/mls/src/main/java/tv/mycujoo/mcls/helper/OverlayViewHelper.kt
+++ b/mls/src/main/java/tv/mycujoo/mcls/helper/OverlayViewHelper.kt
@@ -16,11 +16,13 @@ import tv.mycujoo.mcls.manager.contracts.IViewHandler
 import tv.mycujoo.mcls.widgets.ProportionalImageView
 import tv.mycujoo.mcls.widgets.ScaffoldView
 import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * Helps with View related operations. i.e. Add/Remove overlay view to/from screen.
  *
  */
+@Singleton
 class OverlayViewHelper @Inject constructor(
     private val viewHandler: IViewHandler,
     private val overlayFactory: IOverlayFactory,


### PR DESCRIPTION
By Attaching Player View Before the ticking happen, we are making sure that the MLSPlayerView is Ready before annotationFactory.build(), and annotationFactory.process() happen, this ensures that MLSPlayerView is ready when processing finishes.